### PR TITLE
Fix typo

### DIFF
--- a/pages/language/ref/cells.mdx
+++ b/pages/language/ref/cells.mdx
@@ -80,7 +80,7 @@ Converts Builder to a slice. Alias to `self.endCell().beginParse()`.
 ```tact
 extends fun asCell(self: Builder): Cell;
 ```
-Converts builder to a slice. Alias to `Builder.endCell()`.
+Converts builder to a cell. Alias to `Builder.endCell()`.
 
 ## Cell.beginParse
 ```tact


### PR DESCRIPTION
Fix the confusion between slice and cell that is caused by copy-pasting content from a similar method.
Additionally, there was no newline symbol at the end of the file, which I believe should be there, so my text editor added it.