### PR TITLE
fix[CI]: Added a new workflow and temporarily disabled i18n

### DIFF
--- a/.github/workflows/test-build-nextjs.yml
+++ b/.github/workflows/test-build-nextjs.yml
@@ -1,0 +1,61 @@
+# To not merge, if build fails
+name: Test Next.js build
+
+on:
+  # For new PRs, or those who are ready and/or request a review
+  pull_request:
+    types: ["opened", "edited", "reopened", "synchronize", "ready_for_review", "review_requested"]
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "test-build"
+  cancel-in-progress: true
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: yarn
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+        with:
+          # Automatically inject basePath in your Next.js configuration file and disable
+          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
+          #
+          # You may remove this line if you want to manage the configuration yourself.
+          static_site_generator: next
+
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            .next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build documentation
+        run: yarn build-pages

--- a/next.config.js
+++ b/next.config.js
@@ -55,11 +55,12 @@ export default withNextra({
   images: {
     unoptimized: true
   },
-  i18n: {
-    // locales: ['en', 'zh'],
-    locales: ['en'],
-    defaultLocale: 'en'
-  },
+  // i18n: {
+  //   // locales: ['default', 'en', 'zh'],
+  //   locales: ['default', 'en'],
+  //   defaultLocale: 'default',
+  //   // localeDetection: false,
+  // },
   redirects: () => [
     // Language→Guides pages are moved under Book section
     {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dev": "yarn clean && next",
     "build": "yarn clean && next build",
     "post-build": "echo 'spell checking, link checking, formatting'",
-    "build-pages": "yarn build && next export"
+    "build-pages": "yarn build && next export",
+    "next": "next"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -35,10 +35,10 @@ const config = {
     link: 'https://github.com/tact-lang/tact-docs',
   },
   docsRepositoryBase: 'https://github.com/tact-lang/tact-docs/edit/main/',
-  i18n: [
-    { locale: 'en', text: 'English' },
-    // { locale: 'zh', text: '中文' },
-  ],
+  // i18n: [
+  //   { locale: 'en', text: 'English' },
+  //   // { locale: 'zh', text: '中文' },
+  // ],
   sidebar: {
     autoCollapse: true,
     defaultMenuCollapseLevel: 1,
@@ -47,15 +47,15 @@ const config = {
   feedback: {
     content: null
   },
-  editLink: {
-    text: function useText() {
-      const { locale } = useRouter()
-      return {
-        'en': 'Edit this page on GitHub',
-        // 'zh': '在 GitHub 上编辑此页',
-      }[locale ?? "en"]
-    }
-  },
+  // editLink: {
+  //   text: function useText() {
+  //     const { locale } = useRouter()
+  //     return {
+  //       'en': 'Edit this page on GitHub',
+  //       // 'zh': '在 GitHub 上编辑此页',
+  //     }[locale ?? "en"]
+  //   }
+  // },
   footer: {
     text: <span>
       CC BY 4.0, Tact Software Foundation


### PR DESCRIPTION
- [x] Added the test build CI step, which would run on PRs. And made the current deploy workflow only trigger on pushes to main, which only happens on merges as we have branch protection enabled (good!).

The main issue is still the same — Next.js (the underlying thing our doc theme uses) is very tough then it comes to combining i18n with static export as we do it now. That was the primary reason it took me whole 2 days to make it semi-right, but this time the fix is going to be very tough, [because of this incompatibility](https://nextjs.org/docs/messages/export-no-i18n). I'll try to look into it more, but at the moment I have a bold suggestion to move the docs to https://starlight.astro.build, as it's way easier to manage (I've tried already).

There's [next-intl](https://github.com/amannn/next-intl) package, which may be nice with our setup, but will still require a ton of bike-shredding. In any case, I'll figure out a solution for keeping i18n and static exports.