### PR TITLE
fix: use `+=`, `*=`, `-=` operators

### DIFF
--- a/.github/temp-archive/learn/wallet/wallet-2.mdx
+++ b/.github/temp-archive/learn/wallet/wallet-2.mdx
@@ -126,18 +126,18 @@ contract Wallet {
         require(msg.transfer.seqno == self.seqno, "Invalid seqno");
 
         // Increment seqno
-        self.seqno = self.seqno + 1;
+        self.seqno += 1;
 
         // Send message
         send(SendParameters{value: msg.transfer.amount, to: msg.transfer.to, mode: msg.transfer.mode, body: msg.transfer.body});
     }
 
     receive(msg: Slice) {
-            self.seqno = self.seqno + 1;
+            self.seqno += 1;
     }
 
     receive("notify") {
-            self.seqno = self.seqno + 1;
+            self.seqno += 1;
     }
 
     receive("duplicate") {

--- a/pages/book/cookbook.mdx
+++ b/pages/book/cookbook.mdx
@@ -56,8 +56,8 @@ let sum: Int = 0;
 let i: Int = 0;
 
 repeat (10) {               // repeat exactly 10 times
-    i = i + 1;
-    sum = sum + i;
+    i += 1;
+    sum += i;
 }
 
 ```
@@ -75,7 +75,7 @@ repeat (10) {               // repeat exactly 10 times
 let i: Int = 0;
 
 while (i < 10) {
-    i = i + 1;
+    i += 1;
 }
 ```
 

--- a/pages/book/exit-codes.mdx
+++ b/pages/book/exit-codes.mdx
@@ -137,7 +137,7 @@ Example:
 
 ```tact
 repeat(10000) {
-    self.id = self.id + 1;
+    self.id += 1;
 }
 ```
 

--- a/pages/book/functions.mdx
+++ b/pages/book/functions.mdx
@@ -17,7 +17,7 @@ You can define global function anywhere in your program:
 fun pow(a: Int, c: Int): Int {
   let res: Int = 1;
   repeat(c) {
-    res = res * a;
+    res *= a;
   }
   return res;
 }
@@ -34,7 +34,7 @@ Extension functions allow you to implement extensions for any possible type.
 extends fun pow(self: Int, c: Int) {
   let res: Int = 1;
   repeat(c) {
-    res = res * self;
+    res *= self;
   }
   return res;
 }
@@ -48,7 +48,7 @@ Mutable functions are performing mutation of a value replacing it with an execut
 extends mutates fun pow(self: Int, c: Int) {
   let res: Int = 1;
   repeat(c) {
-    res = res * self;
+    res *= self;
   }
   self = res;
 }
@@ -80,7 +80,7 @@ contract Treasure {
   
   // This means that this contract can receive the comment "Increment" and this function would be called for such messages
   receive("Increment") {
-    self.counter = self.counter + 1;
+    self.counter += 1;
   }
 }
 ```

--- a/pages/book/types.mdx
+++ b/pages/book/types.mdx
@@ -120,7 +120,7 @@ contract HelloWorld {
     }
 
     receive("increment") {
-        self.counter = self.counter + 1;
+        self.counter += 1;
     }
 
     get fun counter(): Int {

--- a/pages/language/libs/dns.mdx
+++ b/pages/language/libs/dns.mdx
@@ -80,7 +80,7 @@ fun dnsExtractTopDomainLength(subdomain: Slice): Int {
         let char: Int = subdomain.loadUint(8); // we do not check domain.length because it MUST contain \0 character
         needBreak = char == 0;
         if (!needBreak) {
-            i = i + 8;
+            i += 8;
         }
     } until (needBreak);
     require(i != 0, "Invalid DNS name");
@@ -167,7 +167,7 @@ trait DNSResolver {
         let delta: Int = 0;
         if (subdomain.preloadUint(8) == 0) {
             subdomain.loadUint(8); // Skip first byte
-            delta = delta + 8;
+            delta += 8;
         }
 
         // Checks correctness


### PR DESCRIPTION
This is a follow-up PR on #118, using more augmented assignment operators in Tact docs