### PR TITLE
chore: Nextra/Next.js suggestions

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/test-build-nextjs.yml
+++ b/.github/workflows/test-build-nextjs.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/next.config.js
+++ b/next.config.js
@@ -52,6 +52,7 @@ const withNextra = nextra({
  * @type {import('next').NextConfig}
  */
 export default withNextra({
+  output: 'export',
   images: {
     unoptimized: true
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "yarn deps && yarn clean && next",
     "build": "yarn deps && yarn clean && next build",
     "post-build": "echo 'spell checking, link checking, formatting'",
-    "build-pages": "yarn build && next export && node ./scripts/redirects-generate.js",
+    "build-pages": "yarn build && node ./scripts/redirects-generate.js",
     "next": "next"
   },
   "devDependencies": {

--- a/pages/_app.mdx
+++ b/pages/_app.mdx
@@ -1,4 +1,6 @@
-// import '../styles.css'
+{/*  import '../styles.css' */}
+
+import React from "react"
 
 export default function App({ Component, pageProps }) {
   return <Component {...pageProps} />


### PR DESCRIPTION
Small (1-2 line) fixes of Nextra/Next.js suggestions

* `_app.tsx` -> `_app.mdx`.
   Closes #120
   
* `output: 'export'` in `next.config.js`.
   Closes #123
   
* max fetch depth for CI to correct "latest modified" times.
   Closes #121