### PR TITLE
chore: Moved Cookbook into its own section

### DIFF
--- a/pages/_meta.js
+++ b/pages/_meta.js
@@ -11,6 +11,10 @@ export default {
     title: "Book",
     type: 'page',
   },
+  cookbook: {
+    title: "Cookbook",
+    type: 'page',
+  },
   language: {
     title: "Language",
     type: 'page',

--- a/pages/book/_meta.js
+++ b/pages/book/_meta.js
@@ -2,7 +2,6 @@ export default {
   index: 'Overview',
   guides: 'Guides',
   cs: 'Cheatsheets',
-  cookbook: 'Cookbook',
   '-- 1': {
     type: 'separator',
     title: 'Fundamentals of Tact',

--- a/pages/book/index.mdx
+++ b/pages/book/index.mdx
@@ -32,18 +32,6 @@ Here are it's main contents:
   />
 </Cards>
 
-### Cookbook
-
-[Cookbook](/book/cookbook) is a handy collection of everyday tasks (and solutions) every Tact developer faces during smart contract development. Use it to avoid re-inventing the wheel.
-
-<Cards>
-  <Cards.Card
-    arrow
-    title="Go to the Cookbook"
-    href="/book/cookbook"
-  />
-</Cards>
-
 ### Book
 
 [**The Tact Book**](/book/types) is a cohesive and streamlined sequence of educational materials about Tact. In general, it assumes that you’re reading it in sequence from front to back. Later parts build on concepts in earlier parts, and earlier parts might not delve into details on a particular topic but will revisit the topic in a later part.

--- a/pages/cookbook/_meta.js
+++ b/pages/cookbook/_meta.js
@@ -1,0 +1,16 @@
+export default {
+  index: 'Overview',
+  '-- Community': {
+    type: 'separator',
+  },
+  'telegram-link': {
+    title: '✈️ Telegram',
+    href: 'https://t.me/tactlang',
+    newWindow: true
+  },
+  'xtwitter-link': {
+    title: '🐦 X/Twitter',
+    href: 'https://twitter.com/tact_language',
+    newWindow: true
+  },
+}

--- a/pages/cookbook/index.mdx
+++ b/pages/cookbook/index.mdx
@@ -1,6 +1,6 @@
 import { Callout } from 'nextra/components'
 
-# Cookbook
+# Cookbook Overview
 
 The core reason for creating the Tact Cookbook is to collect all the experience from Tact developers in one place so that future developers will use it. Compared to the rest of the documentation, this page is more focused on everyday tasks every Tact developer resolves during the development of smart contracts.
 

--- a/pages/cookbook/index.mdx
+++ b/pages/cookbook/index.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components'
 
 # Cookbook Overview
 
-The core reason for creating the Tact Cookbook is to collect all the experience from Tact developers in one place so that future developers will use it. Compared to the rest of the documentation, this page is more focused on everyday tasks every Tact developer resolves during the development of smart contracts.
+The core reason for creating the Tact Cookbook is to collect all the experience from Tact developers in one place so that future developers will use it. Compared to the rest of the documentation, this section is more focused on everyday tasks every Tact developer resolves during the development of smart contracts.
 
 ## Basics
 

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -83,7 +83,9 @@ To re-compile or deploy, refer to the commands in the scripts section of `packag
 
 ### Have some blockchain knowledge already? [#next-1]
 
-See the [Tact Cookbook](/book/cookbook), or check the following cheatsheets to quickly get started!
+See the [Tact Cookbook](/cookbook), which is a handy collection of everyday tasks (and solutions) every Tact developer faces during smart contract development. Use it to avoid re-inventing the wheel.
+
+Alternatively, check the following cheatsheets to quickly get started:
 
 <Cards>
   <Cards.Card
@@ -106,6 +108,7 @@ For custom plugins for your favorite editor and other tooling see the [Tools](/e
 
 Alternatively, take a look at the following broader sections:
 * [Book](/book) helps you learn the language step-by-step
+* [Cookbook](/cookbook) gives you ready-made recipes of Tact code
 * [Language](/language) provides a complete reference of the standard library, grammar and evolution process
 * Finally, [Ecosystem](/ecosystem) describes "what's out there" in the Tacts' and TONs' ecosystems
 
@@ -114,6 +117,11 @@ Alternatively, take a look at the following broader sections:
     icon="📚 "
     title="Read the Book of Tact"
     href="/book"
+  />
+  <Cards.Card
+    icon="🍲 "
+    title="Examine the Cookbook"
+    href="/cookbook"
   />
   <Cards.Card
     icon="🔬 "

--- a/scripts/redirects-generate.js
+++ b/scripts/redirects-generate.js
@@ -125,6 +125,11 @@ const getRedirects = () => [
     subSources: undefined,
     destination: '/book/types#composite-types',
   },
+  {
+    source: '/book/cookbook',
+    subSources: undefined,
+    destination: '/cookbook',
+  },
 ];
 
 /**

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -61,6 +61,9 @@ const config = {
       CC BY 4.0, Tact Software Foundation
     </span>,
   },
+  toc: {
+    backToTop: true,
+  },
   useNextSeoProps() {
     return {
       titleTemplate: '%s – Tact'


### PR DESCRIPTION
* Changed descriptions on the main page
* Added a redirect `/book/cookbook` -> `/cookbook`

As a bonus, added an `Scroll to top` button to all terms of contents on all pages.

Closes #144.