### PR TITLE
Correct the result of `two / 1` in operators.mdx

### DIFF
--- a/pages/book/operators.mdx
+++ b/pages/book/operators.mdx
@@ -114,7 +114,7 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two / 2; // 1
-two / 1; // 0
+two / 1; // 2
 -1 / 5;  // -1
 ```
 


### PR DESCRIPTION
```
let two: Int = 2;
two / 2; // 1
two / 1; // 0
-1 / 5;  // -1
```
`two / 1; // 0`
This is the integer division of 2 by 1, which is 2. However, it seems the comment claims the result to be 0, which is incorrect. The correct result is indeed 2.