### PR TITLE
fix(book/operators)-Modulo

### DIFF
--- a/pages/book/operators.mdx
+++ b/pages/book/operators.mdx
@@ -114,7 +114,7 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two / 2; // 1
-two / 1; // 0
+two / 1; // 2
 -1 / 5;  // -1
 ```
 

--- a/pages/book/operators.mdx
+++ b/pages/book/operators.mdx
@@ -127,7 +127,7 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two % 2; // 0
-two % 1; // 1
+1 % two; // 1
 
 1 % 5;   // 1
 -1 % 5;  // 4


### PR DESCRIPTION
```
let two: Int = 2;
two % 2; // 0
two % 1; // 1
```
The expression `two % 1` should yield 0 instead of 1. The comment here is incorrect. I believe it should be `1 % two`.