### PR TITLE
chore[ci]: Temporarily disable on-push deploy to start adding new Tact features

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -6,8 +6,8 @@ name: Deploy tact-docs to Pages
 
 on:
   # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
+  # push:
+  #   branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
See: #167

I'm almost done with #143 and I thought that it would be nice to start adding new features of Tact 1.3.0 right away.

Because there's no versioning of the docs yet, I suggest we temporarily move to a `workflow_dispatch` mode of updates (manual button press in the Github's Actions UI) until Tact 1.3.0 or #167 releases.