### PR TITLE
feat: Update of the Book→Operators page

### DIFF
--- a/pages/book/message-mode.mdx
+++ b/pages/book/message-mode.mdx
@@ -25,7 +25,7 @@ $+32$      | `SendDestroyIfZero{:tact}`      | Current account must be destroyed
 
 ## Combining modes with flags
 
-To make the [`Int{:tact}`][int] value for `mode` field of SendParameters, you just have to combine base modes with optional flags by applying the [`bitwise OR{:tact}`](/book/operators#binary-bitwise-or) operation.
+To make the [`Int{:tact}`][int] value for `mode` field of `SendParameters{:tact}`, you just have to combine base modes with optional flags by applying the [`bitwise OR{:tact}`](/book/operators#binary-bitwise-or) operation.
 
 For example, if you want to send a regular message and pay transfer fees separately, use the mode $0$ (default) and a flag $+1$ to get `mode` $= 1$, which is equal to using `SendPayGasSeparately{:tact}` constant.
 

--- a/pages/book/operators.mdx
+++ b/pages/book/operators.mdx
@@ -84,14 +84,6 @@ Consider the following code:
 
 Even though this example may be simple, neglection of precedence rules can often lead to confusing situations with operators. The correct order of operations can be ensured by wrapping every operation in [parentheses](#parentheses), since parentheses have the highest precedence of all expressions and operators there is.
 
-That said, Tact's precedence levels are carefully crafted with predictability and convenience in mind, such that the following expression will always hold `true{:tact}`:
-
-```tact
-a / b * b + a % b == a; // true for any Int values of `a` and `b`,
-                        //   except when `b` is equal to 0 and we divide `a` by 0,
-                        //   which is not allowed
-```
-
 ## Parentheses, `()` [#parentheses]
 
 Parentheses (also can be called round brackets, `(){:tact}`) are more of a punctuation symbols than actual operators, but their [precedence](#precedence) is higher than precedence of any other operator. Use parentheses to override order of operations:
@@ -172,7 +164,9 @@ pow(2, 255) * pow(2, 255); // build error: integer overflow!
 
 #### Divide, `/` [#binary-divide]
 
-Binary slash (_division_) operator `/{:tact}` is used for integer division of two values, which truncates towards zero if result is positive, and away from zero if result is negative. An attempt to divide by zero would result in an error with [exit code 4](/book/exit-codes#4): `Integer overflow`.
+Binary slash (_division_) operator `/{:tact}` is used for integer division of two values, which truncates towards zero if result is positive, and away from zero if result is negative. This is also called [rounding down](https://en.wikipedia.org/wiki/Rounding#Rounding_down) (or rounding towards $-∞$), where, for example, result value of $23.7$ gets rounded to $23$, and $−23.2$ gets rounded to $−24$.
+
+An attempt to divide by zero would result in an error with [exit code 4](/book/exit-codes#4): `Integer overflow`.
 
 Can only be applied to values of type [`Int{:tact}`][int]:
 
@@ -184,7 +178,21 @@ two / 1; // 0
 -1 / -5; // 0
 1 / -5;  // -1
 1 / 5;   // 0
+6 / 5;   // 1, rounding down
+-6 / 5;  // -2, rounding down (towards -∞)
 ```
+
+<Callout>
+
+  Because division operator `/{:tact}` in Tact rounds down, the following expression always holds `true{:tact}`:
+
+  ```tact
+  a / b * b + a % b == a; // true for any Int values of `a` and `b`,
+                          //   except when `b` is equal to 0 and we divide `a` by 0,
+                          //   which is an attempt to divide by zero resulting in an error
+  ```
+
+</Callout>
 
 #### Modulo, `%` [#binary-modulo]
 
@@ -462,6 +470,8 @@ two ^ 3; // 1
 ### Bitwise OR, `|` [#binary-bitwise-or]
 
 Binary bar (_bitwise OR_) operator `|{:tact}` applies a [bitwise OR](https://en.wikipedia.org/wiki/Bitwise_operation#OR), which performs the [logical OR](#binary-logical-or) operation on each pair of the corresponding bits of operands. This is useful when we want to apply a specific [bitmask](https://en.wikipedia.org/wiki/Mask_(computing)).
+
+For example, _bitwise OR_ is commonly used in Tact to [combine base modes with optional flags](http://localhost:3000/book/message-mode#combining-modes-with-flags) by masking specific bits to $1$ in order to construct a target [message `mode`](/book/message-mode).
 
 Can only be applied to values of type [`Int{:tact}`][int]:
 

--- a/pages/book/operators.mdx
+++ b/pages/book/operators.mdx
@@ -163,9 +163,9 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 
 ```tact
 let two: Int = 2;
-two * two;           // 4
- 0  * 1_000_000_000; // 0
--1  * 5;             // -5
+two * two;         // 4
+0 * 1_000_000_000; // 0
+-1 * 5;            // -5
 
 pow(2, 255) * pow(2, 255); // build error: integer overflow!
 ```
@@ -178,12 +178,12 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 
 ```tact
 let two: Int = 2;
-two / 2;  // 1
-two / 1;  // 0
--1  / 5;  // -1
--1  / -5; // 0
- 1  / -5; // -1
- 1  / 5;  // 0
+two / 2; // 1
+two / 1; // 0
+-1 / 5;  // -1
+-1 / -5; // 0
+1 / -5;  // -1
+1 / 5;   // 0
 ```
 
 #### Modulo, `%` [#binary-modulo]
@@ -197,9 +197,9 @@ let two: Int = 2;
 two % 2; // 0
 two % 1; // 1
 
-1  % 5;  // 1
+1 % 5;   // 1
 -1 % 5;  // 4
-1  % -5; // -4
+1 % -5;  // -4
 -1 % -5; // -1
 ```
 
@@ -230,7 +230,7 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two + 2; // 4
--1  + 1; // 0
+-1 + 1;  // 0
 
 pow(2, 254) + pow(2, 254);     // 2 * 2^254
 pow(2, 255) + pow(2, 255);     // build error: integer overflow!
@@ -246,7 +246,7 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two - 2; // 0
--1  - 1; // -2
+-1 - 1;  // -2
 
 pow(2, 254) - pow(2, 254); // 0
 pow(2, 255) - pow(2, 255); // 0
@@ -266,8 +266,8 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two >> 1; // 1
- 4  >> 1; // 2
- 5  >> 1; // 2, due to flooring of integer values
+4 >> 1;   // 2
+5 >> 1;   // 2, due to flooring of integer values
 
 pow(2, 254) >> 254; // 1
 ```
@@ -288,8 +288,8 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two << 1; // 4
- 1  << 5; // 1 * 2^5, which is 32
- 2  << 5; // 2 * 2^5, which is 64
+1 << 5;   // 1 * 2^5, which is 32
+2 << 5;   // 2 * 2^5, which is 64
 
 pow(2, 254) == (1 << 254); // true
 pow(2, 254) == 1 << 254; // true, no parentheses needed due to higher precedence of >> over ==
@@ -313,8 +313,8 @@ Binary _greater than_ operator `>{:tact}` returns `true{:tact}` if the left oper
 
 ```tact
 let two: Int = 2;
-two > 2;  // false
--1  > -3; // true
+two > 2; // false
+-1 > -3; // true
 ```
 
 #### Greater than or equal to, `>=` [#binary-greater-equal]
@@ -323,8 +323,8 @@ Binary _greater than or equal to_ operator `>={:tact}` returns `true{:tact}` if 
 
 ```tact
 let two: Int = 2;
-two >= 2;  // true
--1  >= -3; // true
+two >= 2; // true
+-1 >= -3; // true
 ```
 
 #### Less than, `<` [#binary-less]
@@ -333,8 +333,8 @@ Binary _less than_ operator `<{:tact}` returns `true{:tact}` if the left operand
 
 ```tact
 let two: Int = 2;
-two < 2;  // false
--1  < -3; // false
+two < 2; // false
+-1 < -3; // false
 ```
 
 #### Less than or equal to, `<=` [#binary-less-equal]
@@ -417,12 +417,12 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 
 ```tact
 let two: Int = 2;
-two & 1;          // 0
- 4  & 1;          // 0
- 3  & 1;          // 1
- 1  & 1;          // 1
+two & 1; // 0
+4 & 1;   // 0
+3 & 1;   // 1
+1 & 1;   // 1
 
-255        & 0b00001111; // 15
+255 & 0b00001111;        // 15
 0b11110000 & 0b00001111; // 15
 ```
 
@@ -444,11 +444,11 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two ^ 3; // 1
- 4  ^ 1; // 0
- 3  ^ 1; // 3
- 1  ^ 1; // 0
+4 ^ 1;   // 0
+3 ^ 1;   // 3
+1 ^ 1;   // 0
 
-255        ^ 0b00001111; // 240
+255 ^ 0b00001111;        // 240
 0b11110000 ^ 0b00001111; // 240
 ```
 
@@ -468,11 +468,11 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two | 1; // 3
- 4  | 1; // 5
- 3  | 1; // 3
- 1  | 1; // 1
+4 | 1;   // 5
+3 | 1;   // 3
+1 | 1;   // 1
 
-255        | 0b00001111; // 255
+255 | 0b00001111;        // 255
 0b11110000 | 0b00001111; // 255
 ```
 
@@ -491,9 +491,9 @@ Can only be applied to values of type [`Bool{:tact}`][bool]:
 
 ```tact
 let iLikeTact: Bool = true;
-iLikeTact && true;      // true, evaluated both operands
-iLikeTact && false;     // false, evaluated both operands
-false     && iLikeTact; // false, didn't evaluate iLikeTact
+iLikeTact && true;  // true, evaluated both operands
+iLikeTact && false; // false, evaluated both operands
+false && iLikeTact; // false, didn't evaluate iLikeTact
 ```
 
 ### Logical OR, `||` [#binary-logical-or]

--- a/pages/book/operators.mdx
+++ b/pages/book/operators.mdx
@@ -8,9 +8,66 @@ This page lists all the operators in Tact in decreasing order of their [preceden
 
 <Callout>
 
-  Note, that there are no implicit type conversions in Tact, so operators can't be used to, say, add values of different type or compare them in terms of equality without explicitly casting to the same type. That's done with certain functions from the standard library. See [`Int.toString(){:tact}`](/language/ref/strings#inttostring) for an example of such function.
+  Note, that there are no implicit type conversions in Tact, so operators can't be used to, say, add values of different type or compare them in terms of equality without explicitly casting to the same type. That's done with certain functions from the standard library. See [`Int.toString(){:tact}`](/ref/api-strings#inttostring) for an example of such function.
 
 </Callout>
+
+## Table of operators [#table]
+
+The following table lists operators in order of decreasing [precedence](#precedence): from highest to lowest.
+
+Brief description | Operators
+:---------------- | :--------------------------------------------------------------------
+Parentheses       | [`(){:tact}`][paren]
+Unary postfix     | [`!!{:tact}`][nna]
+Unary prefix      | [`+{:tact}`][plus] &nbsp; [`-{:tact}`][neg] &nbsp; [`!{:tact}`][inv]
+Multiplicative    | [`*{:tact}`][mul] &nbsp; [`/{:tact}`][div] &nbsp; [`%{:tact}`][mod]
+Additive          | [`+{:tact}`][add] &nbsp; [`-{:tact}`][sub]
+Shift             | [`>>{:tact}`][shr] &nbsp; [`<<{:tact}`][shl]
+Relation          | [`>{:tact}`][gt] &nbsp; [`>={:tact}`][ge] &nbsp; [`<{:tact}`][lt] &nbsp; [`<={:tact}`][le]
+Equality          | [`=={:tact}`][eq] &nbsp; [`!={:tact}`][eq]
+Bitwise AND       | [`&{:tact}`][b-and]
+Bitwise XOR       | [`^{:tact}`][b-xor]
+Bitwise OR        | [`\|{:tact}`][b-or]
+Logical AND       | [`&&{:tact}`][l-and]
+Logical OR        | [`\|\|{:tact}`][l-or]
+Ternary           | [`?:{:tact}`][ternary]
+Assignment        | [`={:tact}`][assign]
+
+[paren]: #parentheses
+
+[nna]: #unary-non-null-assert
+[plus]: #unary-plus
+[neg]: #unary-negate
+[inv]: #unary-inverse
+
+[mul]: #binary-multiply
+[div]: #binary-divide
+[mod]: #binary-modulo
+
+[add]: #binary-add
+[sub]: #binary-subtract
+
+[shr]: #binary-bitwise-shift-right
+[shl]: #binary-bitwise-shift-left
+
+[gt]: #binary-greater
+[ge]: #binary-greater-equal
+[lt]: #binary-less
+[le]: #binary-less-equal
+
+[eq]: #binary-equality
+
+[b-and]: #binary-bitwise-and
+[b-xor]: #binary-bitwise-xor
+[b-or]: #binary-bitwise-or
+
+[l-and]: #binary-logical-and
+[l-or]: #binary-logical-or
+
+[ternary]: #ternary
+
+[assign]: #assignment
 
 ## Precedence
 
@@ -27,7 +84,15 @@ Consider the following code:
 
 Even though this example may be simple, neglection of precedence rules can often lead to confusing situations with operators. The correct order of operations can be ensured by wrapping every operation in [parentheses](#parentheses), since parentheses have the highest precedence of all expressions and operators there is.
 
-## Parentheses, `()`
+That said, Tact's precedence levels are carefully crafted with predictability and convenience in mind, such that the following expression will always hold `true{:tact}`:
+
+```tact
+a / b * b + a % b == a; // true for any Int values of `a` and `b`,
+                        //   except when `b` is equal to 0 and we divide `a` by 0,
+                        //   which is not allowed
+```
+
+## Parentheses, `()` [#parentheses]
 
 Parentheses (also can be called round brackets, `(){:tact}`) are more of a punctuation symbols than actual operators, but their [precedence](#precedence) is higher than precedence of any other operator. Use parentheses to override order of operations:
 
@@ -98,24 +163,27 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 
 ```tact
 let two: Int = 2;
-two * two;         // 4
-0 * 1_000_000_000; // 0
--1 * 5;            // -5
+two * two;           // 4
+ 0  * 1_000_000_000; // 0
+-1  * 5;             // -5
 
 pow(2, 255) * pow(2, 255); // build error: integer overflow!
 ```
 
 #### Divide, `/` [#binary-divide]
 
-Binary slash (_division_) operator `/{:tact}` is used for integer division of two values, which truncates towards zero. An attempt to divide by zero would result in an error with [exit code 4](/book/exit-codes#4): `Integer overflow`.
+Binary slash (_division_) operator `/{:tact}` is used for integer division of two values, which truncates towards zero if result is positive, and away from zero if result is negative. An attempt to divide by zero would result in an error with [exit code 4](/book/exit-codes#4): `Integer overflow`.
 
 Can only be applied to values of type [`Int{:tact}`][int]:
 
 ```tact
 let two: Int = 2;
-two / 2; // 1
-two / 1; // 2
--1 / 5;  // -1
+two / 2;  // 1
+two / 1;  // 0
+-1  / 5;  // -1
+-1  / -5; // 0
+ 1  / -5; // -1
+ 1  / 5;  // 0
 ```
 
 #### Modulo, `%` [#binary-modulo]
@@ -127,15 +195,15 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two % 2; // 0
-1 % two; // 1
+two % 1; // 1
 
-1 % 5;   // 1
+1  % 5;  // 1
 -1 % 5;  // 4
-1 % -5;  // -4
+1  % -5; // -4
 -1 % -5; // -1
 ```
 
-The simplest way to avoid confusion between the two is to prefer using positive values via [`abs(x: Int){:tact}`](/language/ref/math#abs):
+The simplest way to avoid confusion between the two is to prefer using positive values via [`abs(x: Int){:tact}`](/ref/api-math#abs):
 
 ```tact
 abs(-1) % abs(-5); // 1
@@ -162,7 +230,7 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two + 2; // 4
--1 + 1;  // 0
+-1  + 1; // 0
 
 pow(2, 254) + pow(2, 254);     // 2 * 2^254
 pow(2, 255) + pow(2, 255);     // build error: integer overflow!
@@ -178,16 +246,16 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two - 2; // 0
--1 - 1;  // -2
+-1  - 1; // -2
 
 pow(2, 254) - pow(2, 254); // 0
 pow(2, 255) - pow(2, 255); // 0
 pow(2, 256) - pow(2, 256); // build error: integer overflow!
 ```
 
-### Bitwise [#binary-bitwise]
+### Bitwise shifts [#binary-bitwise-shifts]
 
-Manipulate individual bits.
+Shift bits to the left or to the right.
 
 #### Shift right, `>>` [#binary-bitwise-shift-right]
 
@@ -198,8 +266,8 @@ Can only be applied to values of type [`Int{:tact}`][int]:
 ```tact
 let two: Int = 2;
 two >> 1; // 1
-4 >> 1;   // 2
-5 >> 1;   // 2, due to flooring of integer values
+ 4  >> 1; // 2
+ 5  >> 1; // 2, due to flooring of integer values
 
 pow(2, 254) >> 254; // 1
 ```
@@ -213,15 +281,15 @@ pow(2, 254) >> 254; // 1
 
 #### Shift left, `<<` [#binary-bitwise-shift-left]
 
-Binary double greater than (_bitwise shift right_) operator `<<{:tact}` returns an integer which binary representation is the _left operand_ value shifted by the _right operand_ number of bits to the left. Excess bits shifted off to the left are discarded, and zero bits are shifted in from the right. This is a more effective way to multiply the _left operand_ by $2^n$, where $n$ is equal to the _right operand_. Going beyond the maximum value of an [`Int{:tact}`][int] will result in an error with [exit code 4](/book/exit-codes#4): `Integer overflow`.
+Binary double greater than (_bitwise shift left_) operator `<<{:tact}` returns an integer which binary representation is the _left operand_ value shifted by the _right operand_ number of bits to the left. Excess bits shifted off to the left are discarded, and zero bits are shifted in from the right. This is a more effective way to multiply the _left operand_ by $2^n$, where $n$ is equal to the _right operand_. Going beyond the maximum value of an [`Int{:tact}`][int] will result in an error with [exit code 4](/book/exit-codes#4): `Integer overflow`.
 
 Can only be applied to values of type [`Int{:tact}`][int]:
 
 ```tact
 let two: Int = 2;
 two << 1; // 4
-1 << 5;   // 1 * 2^5, which is 32
-2 << 5;   // 2 * 2^5, which is 64
+ 1  << 5; // 1 * 2^5, which is 32
+ 2  << 5; // 2 * 2^5, which is 64
 
 pow(2, 254) == (1 << 254); // true
 pow(2, 254) == 1 << 254; // true, no parentheses needed due to higher precedence of >> over ==
@@ -235,57 +303,51 @@ pow(2, 255) == 1 << 255; // true, but we're very close to overflow here!
 
 </Callout>
 
-#### Bitwise AND, `&` [#binary-bitwise-and]
+### Relation [#binary-relation]
 
-Binary ampersand (_bitwise and_) operator `&{:tact}` applies a [bitwise AND](https://en.wikipedia.org/wiki/Bitwise_operation#AND), which performs the [logical AND](#binary-logical-and) operation on each pair of the corresponding bits of operands. This is useful when we want to clear selected bits off a number, where each bit represents an individual flag or a boolean state, which makes it possible to "store" up to $257$ boolean values per integer, as all integers in Tact are $257$-bit signed.
+Find bigger, smaller or equal values.
 
-Can only be applied to values of type [`Int{:tact}`][int]:
+#### Greater than, `>` [#binary-greater]
 
-```tact
-let two: Int = 2;
-two & 1;          // 0
-4 & 1;            // 0
-3 & 1;            // 1
-1 & 1;            // 1
-255 & 0b00001111; // 15
-```
-
-<Callout>
-
-  [Bitwise AND - Wikipedia](https://en.wikipedia.org/wiki/Bitwise_operation#AND)\
-  [Bit manipulation - Wikipedia](https://en.wikipedia.org/wiki/Bit_manipulation)
-
-</Callout>
-
-#### Bitwise OR, `|` [#binary-bitwise-or]
-
-Binary bar (_bitwise or_) operator `|{:tact}` applies a [bitwise OR](https://en.wikipedia.org/wiki/Bitwise_operation#OR), which performs the [logical OR](#binary-logical-or) operation on each pair of the corresponding bits of operands. This is useful when we want to apply a specific [bitmask](https://en.wikipedia.org/wiki/Mask_(computing)).
-
-Can only be applied to values of type [`Int{:tact}`][int]:
+Binary _greater than_ operator `>{:tact}` returns `true{:tact}` if the left operand is greater than the right operand, and `false{:tact}` otherwise. Can only be applied to values of type [`Int{:tact}`][int]:
 
 ```tact
 let two: Int = 2;
-two | 1; // 3
-4 | 1;   // 5
-3 | 1;   // 3
-1 | 1;   // 1
-
-255 | 0b00001111;        // 255
-0b11110000 | 0b00001111; // 255
+two > 2;  // false
+-1  > -3; // true
 ```
 
-<Callout>
+#### Greater than or equal to, `>=` [#binary-greater-equal]
 
-  [Bitwise OR - Wikipedia](https://en.wikipedia.org/wiki/Bitwise_operation#OR)\
-  [Bit manipulation - Wikipedia](https://en.wikipedia.org/wiki/Bit_manipulation)
+Binary _greater than or equal to_ operator `>={:tact}` returns `true{:tact}` if the left operand is greater than or to the right operand, and `false{:tact}` otherwise. Can only be applied to values of type [`Int{:tact}`][int]:
 
-</Callout>
+```tact
+let two: Int = 2;
+two >= 2;  // true
+-1  >= -3; // true
+```
 
-### Comparison [#binary-comparison]
+#### Less than, `<` [#binary-less]
 
-Perform inequality and equality checks, find bigger, smaller or equal values.
+Binary _less than_ operator `<{:tact}` returns `true{:tact}` if the left operand is less than the right operand, and `false{:tact}` otherwise. Can only be applied to values of type [`Int{:tact}`][int]:
 
-#### Equal and not equal, `==` `!=` [#binary-equality]
+```tact
+let two: Int = 2;
+two < 2;  // false
+-1  < -3; // false
+```
+
+#### Less than or equal to, `<=` [#binary-less-equal]
+
+Binary _less than or equal to_ operator `<={:tact}` returns `true{:tact}` if the left operand is less than or equal to the right operand, and `false{:tact}` otherwise. Can only be applied to values of type [`Int{:tact}`][int]:
+
+```tact
+let two: Int = 2;
+two <= 2; // true
+-1 <= -3; // false
+```
+
+### Equality and inequality, `==` `!=` [#binary-equality]
 
 Binary equality (_equal_) operator `=={:tact}` checks whether its two operands are _equal_, returning a result of type [`Bool{:tact}`][bool].
 
@@ -347,45 +409,79 @@ nullable == anotherNullable; // false
 nullable != anotherNullable; // true
 ```
 
-#### Greater than, `>` [#binary-greater]
+### Bitwise AND, `&` [#binary-bitwise-and]
 
-Binary _greater than_ operator `>{:tact}` returns `true{:tact}` if the left operand is greater than the right operand, and `false{:tact}` otherwise. Can only be applied to values of type [`Int{:tact}`][int]:
+Binary ampersand (_bitwise AND_) operator `&{:tact}` applies a [bitwise AND](https://en.wikipedia.org/wiki/Bitwise_operation#AND), which performs the [logical AND](#binary-logical-and) operation on each pair of the corresponding bits of operands. This is useful when we want to clear selected bits off a number, where each bit represents an individual flag or a boolean state, which makes it possible to "store" up to $257$ boolean values per integer, as all integers in Tact are $257$-bit signed.
 
-```tact
-let two: Int = 2;
-two > 2; // false
--1 > -3; // true
-```
-
-#### Greater than or equal to, `>=` [#binary-greater-equal]
-
-Binary _greater than or equal to_ operator `>={:tact}` returns `true{:tact}` if the left operand is greater than or to the right operand, and `false{:tact}` otherwise. Can only be applied to values of type [`Int{:tact}`][int]:
+Can only be applied to values of type [`Int{:tact}`][int]:
 
 ```tact
 let two: Int = 2;
-two >= 2; // true
--1 >= -3; // true
+two & 1;          // 0
+ 4  & 1;          // 0
+ 3  & 1;          // 1
+ 1  & 1;          // 1
+
+255        & 0b00001111; // 15
+0b11110000 & 0b00001111; // 15
 ```
 
-#### Less than, `<` [#binary-less]
+<Callout>
 
-Binary _less than_ operator `<{:tact}` returns `true{:tact}` if the left operand is less than the right operand, and `false{:tact}` otherwise. Can only be applied to values of type [`Int{:tact}`][int]:
+  [Bitwise AND - Wikipedia](https://en.wikipedia.org/wiki/Bitwise_operation#AND)\
+  [Bit manipulation - Wikipedia](https://en.wikipedia.org/wiki/Bit_manipulation)
+
+</Callout>
+
+### Bitwise XOR, `^` [#binary-bitwise-xor]
+
+Binary caret (_bitwise XOR_) operator `^{:tact}` applies a [bitwise XOR](https://en.wikipedia.org/wiki/Bitwise_operation#XOR), which performs the [logical exclusive OR](https://en.wikipedia.org/wiki/Exclusive_or) operation on each pair of the corresponding bits of operands. The result in each position is $1$ if only one of the bits is $1$, but will be $0$ if both are $0$ or both are $1$. In this it performs the comparison of two bits, giving $1$ if the two bits are different, and $0$ if they are the same.
+
+It is useful for inverting selected bits of an operand (also called toggle or flip), as any bit may be toggled by "XORing" it with $1$.
+
+Can only be applied to values of type [`Int{:tact}`][int]:
 
 ```tact
 let two: Int = 2;
-two < 2; // false
--1 < -3; // false
+two ^ 3; // 1
+ 4  ^ 1; // 0
+ 3  ^ 1; // 3
+ 1  ^ 1; // 0
+
+255        ^ 0b00001111; // 240
+0b11110000 ^ 0b00001111; // 240
 ```
 
-#### Less than or equal to, `<=` [#binary-less-equal]
+<Callout>
 
-Binary _less than or equal to_ operator `<={:tact}` returns `true{:tact}` if the left operand is less than or equal to the right operand, and `false{:tact}` otherwise. Can only be applied to values of type [`Int{:tact}`][int]:
+  [Bitwise XOR - Wikipedia](https://en.wikipedia.org/wiki/Bitwise_operation#XOR)\
+  [Bit manipulation - Wikipedia](https://en.wikipedia.org/wiki/Bit_manipulation)
+
+</Callout>
+
+### Bitwise OR, `|` [#binary-bitwise-or]
+
+Binary bar (_bitwise OR_) operator `|{:tact}` applies a [bitwise OR](https://en.wikipedia.org/wiki/Bitwise_operation#OR), which performs the [logical OR](#binary-logical-or) operation on each pair of the corresponding bits of operands. This is useful when we want to apply a specific [bitmask](https://en.wikipedia.org/wiki/Mask_(computing)).
+
+Can only be applied to values of type [`Int{:tact}`][int]:
 
 ```tact
 let two: Int = 2;
-two <= 2; // true
--1 <= -3; // false
+two | 1; // 3
+ 4  | 1; // 5
+ 3  | 1; // 3
+ 1  | 1; // 1
+
+255        | 0b00001111; // 255
+0b11110000 | 0b00001111; // 255
 ```
+
+<Callout>
+
+  [Bitwise OR - Wikipedia](https://en.wikipedia.org/wiki/Bitwise_operation#OR)\
+  [Bit manipulation - Wikipedia](https://en.wikipedia.org/wiki/Bit_manipulation)
+
+</Callout>
 
 ### Logical AND, `&&` [#binary-logical-and]
 
@@ -395,9 +491,9 @@ Can only be applied to values of type [`Bool{:tact}`][bool]:
 
 ```tact
 let iLikeTact: Bool = true;
-iLikeTact && true;  // true
-iLikeTact && false; // false, evaluated both operands
-false && iLikeTact; // false, didn't evaluate iLikeTact
+iLikeTact && true;      // true, evaluated both operands
+iLikeTact && false;     // false, evaluated both operands
+false     && iLikeTact; // false, didn't evaluate iLikeTact
 ```
 
 ### Logical OR, `||` [#binary-logical-or]
@@ -408,9 +504,9 @@ Can only be applied to values of type [`Bool{:tact}`][bool]:
 
 ```tact
 let iLikeSnails: Bool = false;
-iLikeSnails && true;  // true
-iLikeSnails && false; // false, evaluated both operands
-true && iLikeSnails;  // true, didn't evaluate iLikeSnails
+iLikeSnails || true;  // true, evaluated both operands
+iLikeSnails || false; // false, evaluated both operands
+true || iLikeSnails;  // true, didn't evaluate iLikeSnails
 ```
 
 ## Ternary, `?:` [#ternary]
@@ -443,7 +539,7 @@ false ? 1 : true ? 2 : 3;    // 2
 // need additional parentheses for consequence cases (parts in-between ? and :)
 false ? (false ? 1 : 2) : 3; // 3
 false ? false ? 1 : 2 : 3;   // SYNTAX ERROR!
-true ? (false ? 1 : 2) : 3;  // 2
+true  ? (false ? 1 : 2) : 3; // 2
 ```
 
 ## Assignment, `=` [#assignment]

--- a/pages/book/operators.mdx
+++ b/pages/book/operators.mdx
@@ -164,7 +164,7 @@ pow(2, 255) * pow(2, 255); // build error: integer overflow!
 
 #### Divide, `/` [#binary-divide]
 
-Binary slash (_division_) operator `/{:tact}` is used for integer division of two values, which truncates towards zero if result is positive, and away from zero if result is negative. This is also called [rounding down](https://en.wikipedia.org/wiki/Rounding#Rounding_down) (or rounding towards $-∞$), where, for example, result value of $23.7$ gets rounded to $23$, and $−23.2$ gets rounded to $−24$.
+Binary slash (_division_) operator `/{:tact}` is used for integer division of two values, which truncates towards zero if result is positive, and away from zero if result is negative. This is also called [rounding down](https://en.wikipedia.org/wiki/Rounding#Rounding_down) (or rounding towards $-∞$).
 
 An attempt to divide by zero would result in an error with [exit code 4](/book/exit-codes#4): `Integer overflow`.
 
@@ -184,7 +184,7 @@ two / 1; // 0
 
 <Callout>
 
-  Because division operator `/{:tact}` in Tact rounds down, the following expression always holds `true{:tact}`:
+  Note that the following relationship between the division and modulo operators always holds for `Int{:tact}` type:
 
   ```tact
   a / b * b + a % b == a; // true for any Int values of `a` and `b`,


### PR DESCRIPTION
* All precedences match Tact 1.3.0
* Added bitwise XOR operator `^`
* Fixed minor typos and corrected some descriptions
* Added a table of operators in decreasing order of their precedences

Note, that the only link leading to Language section now has a proper link to the Reference section. This is intentional, as the Lang->Ref rename is almost there :)

Closes #192 (new operator precedence + a table) — this is the main issue target of this PR
Closes #202 (small error)
Closes #181 (small note)
Closes #178 (small correction)
