### PR TITLE
Add details regarding abstract and virtual functions in traits

### DIFF
--- a/pages/book/contracts.mdx
+++ b/pages/book/contracts.mdx
@@ -194,7 +194,7 @@ contract HelloWorld {
 
 These functions behave similarly to private methods in popular object-oriented languages — they're internal to contracts and can be called by prefixing them with a special [identifier `self{:tact}`](#field-access). That's why internal functions can sometimes be referred to as "contract methods".
 
-Internal functions can access the contract's [persistent state variables](#variables) and [constants](#constants).
+Internal functions can access the contract's [persistent state variables](#variables) and [constants](#constants). If declared in a [traits](/book/types#traits), they can be declared as [virtual or abstract](/book/functions#virtual-and-abstract-functions) and overriden in the contract inheriting it.
 
 They can only be called from [receivers](#receiver-functions), [getters](#getter-functions) and other internal functions, but not from other contracts or [`init(){:tact}`](#init-function).
 

--- a/pages/book/contracts.mdx
+++ b/pages/book/contracts.mdx
@@ -30,7 +30,7 @@ Each contract can contain:
 * [Receiver functions](#receiver-functions)
 * [Internal functions](#internal-functions)
 
-Furthermore, contracts can inherit all the declarations from [traits](/book/types#traits) and override some of their default behaviours.
+Furthermore, contracts can inherit all the declarations and definitions from [traits](/book/types#traits) and override some of their default behaviours. If declared or defined in a trait, internal functions and constants can be marked as [virtual or abstract](/book/functions#virtual-and-abstract-functions) and overriden in contracts inheriting from the trait.
 
 ### Persistent state variables [#variables]
 
@@ -199,7 +199,7 @@ contract HelloWorld {
 
 These functions behave similarly to private methods in popular object-oriented languages — they're internal to contracts and can be called by prefixing them with a special [identifier `self{:tact}`](#field-access). That's why internal functions can sometimes be referred to as "contract methods".
 
-Internal functions can access the contract's [persistent state variables](#variables) and [constants](#constants). If declared in a [traits](/book/types#traits), they can be declared as [virtual or abstract](/book/functions#virtual-and-abstract-functions) and overriden in the contract inheriting it.
+Internal functions can access the contract's [persistent state variables](#variables) and [constants](#constants).
 
 They can only be called from [receivers](#receiver-functions), [getters](#getter-functions) and other internal functions, but not from other contracts or [`init(){:tact}`](#init-function).
 

--- a/pages/book/functions.mdx
+++ b/pages/book/functions.mdx
@@ -23,6 +23,34 @@ fun pow(a: Int, c: Int): Int {
 }
 ```
 
+## Virtual and abstract functions
+
+You can allow the contract inheriting a [traits](/book/types#traits) to modify an internal function, if it has the `virtual` keyword, using `override`. The function can be also marked as `abstract`, in which case the inheriting contract has to define its implementation:
+
+```tact
+trait FilterTrait with Ownable {
+    virtual fun filterMessage(): Bool { // virtual functions can be overridden by users of this trait
+        if (sender() == self.owner) {
+            return false;
+        }
+        return true;
+    }
+
+    abstract fun specialFilter(): Bool;
+}
+
+contract Filter with FilterTrait {
+    // the trait allows us to override the default behavior
+    override fun filterMessage(): Bool {
+        return true;
+    }
+
+    override fun specialFilter(): Bool {
+      return true;
+    }
+}
+````
+
 ## Extension function
 
 Extension functions allow you to implement extensions for any possible type.

--- a/pages/book/functions.mdx
+++ b/pages/book/functions.mdx
@@ -30,10 +30,7 @@ You can allow the contract inheriting a [traits](/book/types#traits) to modify a
 ```tact
 trait FilterTrait with Ownable {
     virtual fun filterMessage(): Bool { // virtual functions can be overridden by users of this trait
-        if (sender() == self.owner) {
-            return false;
-        }
-        return true;
+        return sender() != self.owner;
     }
 
     abstract fun specialFilter(): Bool;

--- a/pages/book/types.mdx
+++ b/pages/book/types.mdx
@@ -138,7 +138,9 @@ Read more about them on the dedicated page: [Contracts](/book/contracts).
 
 ### Traits
 
-Tact doesn't support classical class inheritance, but instead introduces the concept of _traits_, which can be viewed as abstract contracts (like abstract classes in popular object-oriented languages). They have the same structure as [contracts](#contracts), but can't [initialize persistent state variables](/book/contracts#init-function), while allowing to override some of their behaviors.
+Tact doesn't support classical class inheritance, but instead introduces the concept of _traits_, which can be viewed as abstract contracts (like abstract classes in popular object-oriented languages). They have the same structure as [contracts](#contracts), but can't [initialize persistent state variables](/book/contracts#init-function).
+
+A trait can also let the contract inheriting it to override the behavior of its [functions](/book/functions#virtual-and-abstract-functions) and the value of its [constants](/book/constants#virtual-and-abstract-constants).
 
 Example of a trait [`Ownable`](/language/libs/ownable#ownable) from [`@stdlib/ownable`](/language/libs/ownable):
 


### PR DESCRIPTION
Hi!

I noticed that the docs didn't include any mention of `virtual` and `abstract` functions in traits, which can be overridden in the implementation contract. The virtual keyword for functions can be seen in an example in the [Tact by Example](https://tact-by-example.org/05-your-own-trait) website, for instance.

This is a great feature of Tact, so I think it's worth it to include it in the official docs! I also added references to it in other pages which were relevant.