### PR TITLE
feat: send excessive funds from receiver function back to the sender

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -50,6 +50,11 @@ message Add {
     amount: Int as uint32;
 }
 
+message AddOk {
+    queryId: Int as uint64;
+    amount: Int as uint32;
+}
+
 contract SimpleCounter with Deployable {
     id: Int as uint32;
     counter: Int as uint32;
@@ -61,6 +66,7 @@ contract SimpleCounter with Deployable {
 
     receive(msg: Add) {
         self.counter += msg.amount;
+        self.notify(AddOk{queryId: msg.queryId, amount: msg.amount}.toCell());
     }
 
     get fun counter(): Int {

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -40,17 +40,12 @@ It will create a new project with the simple counter contract:
 
 Your first contract project is written and compiled already! Go check it out by moving into the relevant directory — `cd simple-counter/contracts{:shell}`.
 
-It would look something like that:
+Here's how it would look like:
 
 ```tact
 import "@stdlib/deploy";
 
 message Add {
-    queryId: Int as uint64;
-    amount: Int as uint32;
-}
-
-message AddOk {
     queryId: Int as uint64;
     amount: Int as uint32;
 }
@@ -66,7 +61,9 @@ contract SimpleCounter with Deployable {
 
     receive(msg: Add) {
         self.counter += msg.amount;
-        self.notify(AddOk{queryId: msg.queryId, amount: msg.amount}.toCell());
+
+        // Notify the caller that the receiver was executed and forward remaining value back
+        self.notify("Cashback".asComment());
     }
 
     get fun counter(): Int {

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -40,7 +40,7 @@ It will create a new project with the simple counter contract:
 
 Your first contract project is written and compiled already! Go check it out by moving into the relevant directory — `cd simple-counter/contracts{:shell}`.
 
-Here's how it would look like:
+It would look something like that:
 
 ```tact
 import "@stdlib/deploy";


### PR DESCRIPTION
Closes #231

Alternatively, we may just send `null` in `self.notify()`, but that would be less descriptive, so I went with the same approach used in `@stdlib/deploy`. And so it "notifies" the sender about the `AddOk` message, alongside with returning remaining value from the obtained message (implicitly)

UPD: Decided to just use `self.notify("Cashback".asComment());`