### PR TITLE
feat: bounced type constructor description

### DIFF
--- a/pages/book/bounced.mdx
+++ b/pages/book/bounced.mdx
@@ -2,33 +2,35 @@ import { Callout } from 'nextra-theme-docs'
 
 # Bounced messages
 
-When a contract sends a message with a flag bounce set to true, then if the message wasn't processed properly, it would bounce back to the sender. This is useful when you want to make sure that the message was processed properly and if not - revert the changes.
+When a contract sends a message with a flag `bounce` set to `true{:tact}`, then if the message wasn't processed properly, it would bounce back to the sender. This is useful when you want to make sure that the message was processed properly and if not — revert the changes.
 
 ## Caveats
 
-Currently in TON bounced messages have only 224 usable data bits in the message and no references. This means that you can't recover much of the data from the bounced message. This is a limitation of the TON blockchain and will be fixed in the future. Tact helps you to check if your message fits the limit and if not - it will suggest to use a special type modifier `bounced<T>` for the receiver that would construct a partial representation that fits into the required limits.
+Currently, bounced messages in TON have only 224 usable data bits in the message body and don't have any references. This means that you can't recover much of the data from the bounced message. This is a limitation of the TON blockchain and will be fixed in the future. Tact helps you to check if your message fits the limit and in case it doesn't — suggests using a special type constructor `bounced<T>{:tact}` for the bounced message receiver, that would construct a partial representation of the message that fits into the required limits.
 
-## Bounced messages in Tact
+## Bounced message receiver
 
 <Callout type="warning" emoji="⚠️">
-Bounced text messages are not supported yet.
+
+  Bounced text messages are not supported yet.
+
 </Callout>
 
-To receive a bounced message you need to define a `bounced` receiver in your contract or a trait:
+To receive a bounced message, define a `bounced` [receiver function](/book/contracts#receiver-functions) in your [contract](/book/contracts) or a [trait](/book/types#traits):
 
-```tact
+```tact {2-4}
 contract MyContract {
-    bounced(src: bounced<MyMessage>) {
+    bounced(msg: bounced<MyMessage>) {
         // ...
     }
 }
 ```
 
-To process bounced messages manually, you can use a fallback definition that handles raw `Slice` instead of a message:
+To process bounced messages manually, you can use a fallback definition that handles a raw [`Slice{:tact}`](/book/types#primitive-types) directly. Note, that such receiver will get **all** the bounced messages produced by your contract:
 
-```tact
+```tact /rawMsg: Slice/
 contract MyContract {
-    bounced(src: Slice) {
+    bounced(rawMsg: Slice) {
         // ...
     }
 }

--- a/pages/book/types.mdx
+++ b/pages/book/types.mdx
@@ -44,6 +44,8 @@ Using individual means of storage often becomes cumbersome, so there are ways to
 * [Structs and Messages](#structs-and-messages) — data structures with typed fields.
 * [Optionals](#optionals) — `null{:tact}` values for variables or fields of [Structs and Messages](#structs-and-messages).
 
+In addition to the composite types above, Tact provides a special type constructor [`bounced<T>{:tact}`](/book/bounced), which can only be specified in [bounced message receivers](/book/bounced).
+
 Note, while [contracts](#contracts) and [traits](#traits) are also considered a part of the Tacts type system, one can't pass them around like [Structs and Messages](#structs-and-messages). Instead, it's possible to obtain the initial state of the given contract by using the [`initOf{:tact}`](/book/expressions#initof) expression.
 
 ### Maps


### PR DESCRIPTION
Closes #186

Specified a `bounced<T>` type constructor on the `/book/types` page and made a bunch of small edits on the `/book/bounced` page.