### PR TITLE
chore: highlighting-related housekeeping

### DIFF
--- a/pages/book/bounced.mdx
+++ b/pages/book/bounced.mdx
@@ -16,7 +16,7 @@ Currently, bounced messages in TON have only 224 usable data bits in the message
 
 </Callout>
 
-To receive a bounced message, define a `bounced` [receiver function](/book/contracts#receiver-functions) in your [contract](/book/contracts) or a [trait](/book/types#traits):
+To receive a bounced message, define a `bounced(){:tact}` [receiver function](/book/contracts#receiver-functions) in your [contract](/book/contracts) or a [trait](/book/types#traits):
 
 ```tact {2-4}
 contract MyContract {

--- a/pages/book/contracts.mdx
+++ b/pages/book/contracts.mdx
@@ -46,7 +46,7 @@ contract Example {
 }
 ```
 
-State variables must have a default value or initialized in [`init(){:tact}`](#init-function) function, that runs on deployment of the contract. The only exception is persistent state variables of type [`map<k, v>{:tact}`](/book/maps) since they are initialized empty by default.
+State variables must have a default value or initialized in [`init(){:tact}`](#init-function) function, that runs on deployment of the contract. The only exception is persistent state variables of type [`map<K, V>{:tact}`](/book/maps) since they are initialized empty by default.
 
 <Callout>
 

--- a/pages/book/maps.mdx
+++ b/pages/book/maps.mdx
@@ -2,7 +2,7 @@
 
 import { Callout } from 'nextra/components'
 
-The [composite type](/book/types#composite-types) `map<k, v>{:tact}` is used as a way to associate keys of type `k` with corresponding values of type `v`.
+The [composite type](/book/types#composite-types) `map<K, V>{:tact}` is used as a way to associate keys of type `K{:tact}` with corresponding values of type `V{:tact}`.
 
 For example, `map<Int, Int>{:tact}` uses [`Int{:tact}`][int] type for its keys and values:
 
@@ -50,7 +50,7 @@ contract Example {
 }
 ```
 
-Note, that [persistent state variables](/book/contracts#variables) of type `map<k, v>{:tact}` are initialized empty by default and don't need default values or an initialization in the [`init(){:tact}` function](/book/contracts#init-function).
+Note, that [persistent state variables](/book/contracts#variables) of type `map<K, V>{:tact}` are initialized empty by default and don't need default values or an initialization in the [`init(){:tact}` function](/book/contracts#init-function).
 
 ### Set values, `.set()` [#set]
 
@@ -199,7 +199,7 @@ foreach (key, value in fizz) {
 
 Read more about it: [`foreach{:tact}` loop in Book→Statements](/book/statements#foreach-loop).
 
-Note, that it's also possible to use maps as simple arrays if you define a `map<Int, V>{:tact}` with an [`Int{:tact}`][int] type for the keys, any allowed `V` type for values and keep track of the number of items in the separate variable:
+Note, that it's also possible to use maps as simple arrays if you define a `map<Int, V>{:tact}` with an [`Int{:tact}`][int] type for the keys, any allowed `V{:tact}` type for values and keep track of the number of items in the separate variable:
 
 ```tact
 contract Iteration {

--- a/pages/book/message-mode.mdx
+++ b/pages/book/message-mode.mdx
@@ -25,7 +25,7 @@ $+32$      | `SendDestroyIfZero{:tact}`      | Current account must be destroyed
 
 ## Combining modes with flags
 
-To make the [`Int{:tact}`][int] value for `mode` field of `SendParameters{:tact}`, you just have to combine base modes with optional flags by applying the [`bitwise OR{:tact}`](/book/operators#binary-bitwise-or) operation.
+To make the [`Int{:tact}`][int] value for `mode` field of `SendParameters{:tact}`, you just have to combine base modes with optional flags by applying the [bitwise OR](/book/operators#binary-bitwise-or) operation.
 
 For example, if you want to send a regular message and pay transfer fees separately, use the mode $0$ (default) and a flag $+1$ to get `mode` $= 1$, which is equal to using `SendPayGasSeparately{:tact}` constant.
 

--- a/pages/book/operators.mdx
+++ b/pages/book/operators.mdx
@@ -371,7 +371,7 @@ Both operators can be applied to the following list of types and values:
 * [`Cell{:tact}`][p], implicitly compares via `.hash(){:tact}`
 * [`Slice{:tact}`][p], implicitly compares via `.hash(){:tact}`
 * [`String{:tact}`][p]
-* [`map<k, v>{:tact}`](/book/maps), but only if their key and value types are identical
+* [`map<K, V>{:tact}`](/book/maps), but only if their key and value types are identical
 * [Optionals and `null{:tact}` value](/book/optionals)
 
 ```tact
@@ -399,7 +399,7 @@ emptyCell() != emptyCell(); // false
 "A" == "A"; // true
 "A" != "A"; // false
 
-// map<k, v>:
+// map<K, V>:
 let map1: map<Int, Int> = emptyMap();
 let map2: map<Int, Int> = emptyMap();
 map1 == map2; // true

--- a/pages/book/optionals.mdx
+++ b/pages/book/optionals.mdx
@@ -6,7 +6,7 @@ As it was mentioned in [type system overview](/book/types#optionals), all [primi
 
 [Variables](/book/statements#let) or fields of [Structs](/book/structs-and-messages#structs) and [Messages](/book/structs-and-messages#messages) that can hold `null{:tact}` are called "optionals". They're useful to reduce state size when the variable isn't necessarily used.
 
-You can make any variable or a field an optional by adding a question mark (`?{:tact}`) after its type declaration. The only exceptions are [`map<k, v>{:tact}`](/book/maps) and [`bounced<Msg>{:tact}`](/book/bounced#bounced-messages-in-tact), where you can't make them, inner key/value type (in case of a map) or the inner [Message](/book/structs-and-messages#messages) (in case of a bounced) optional.
+You can make any variable or a field an optional by adding a question mark (`?{:tact}`) after its type declaration. The only exceptions are [`map<K, V>{:tact}`](/book/maps) and [`bounced<Msg>{:tact}`](/book/bounced#bounced-messages-in-tact), where you can't make them, inner key/value type (in case of a map) or the inner [Message](/book/structs-and-messages#messages) (in case of a bounced) optional.
 
 Optional variables or optional fields that are not defined hold the `null{:tact}` value by default. You cannot access them without checking for `null{:tact}` first. But if you're certain they are not `null{:tact}` at a given moment, use the [non-null assertion operator `!!{:tact}`](/book/operators#unary-non-null-assert) to access their value.
 

--- a/pages/book/types.mdx
+++ b/pages/book/types.mdx
@@ -50,9 +50,9 @@ Note, while [contracts](#contracts) and [traits](#traits) are also considered a 
 
 ### Maps
 
-The type [`map<k, v>{:tact}`][maps] is used as a way to associate keys of type `k` with corresponding values of type `v`.
+The type [`map<K, V>{:tact}`][maps] is used as a way to associate keys of type `K{:tact}` with corresponding values of type `V{:tact}`.
 
-Example of a [`map<k, v>{:tact}`][maps]:
+Example of a [`map<K, V>{:tact}`][maps]:
 
 ```tact
 let mapExample: map<Int, Int> = emptyMap(); // empty map with Int keys and values

--- a/pages/cookbook/data-structures.mdx
+++ b/pages/cookbook/data-structures.mdx
@@ -6,7 +6,7 @@ Data structures are data organization, management, and storage formats that are 
 
 This page lists a handy collection of data structures implemented in Tact for your day-to-day needs and beyond.
 
-All of the data structures listed here are made using the built-in [`map<k, v>{:tact}`][map] type. For the description and basic usage of maps see the [dedicated page in the Book][map].
+All of the data structures listed here are made using the built-in [`map<K, V>{:tact}`][map] type. For the description and basic usage of maps see the [dedicated page in the Book][map].
 
 ## Array
 

--- a/pages/ref/core-advanced.mdx
+++ b/pages/ref/core-advanced.mdx
@@ -234,7 +234,7 @@ $+16$      | `ReserveBounceIfActionFail{:tact}` | Bounces the transaction if res
 
 ### Combining modes with flags [#nativereserve-combining-modes-with-flags]
 
-To make the [`Int{:tact}`][int] value for `mode` parameter, you just have to combine base modes with optional flags by applying the [`bitwise OR{:tact}`](/book/operators#binary-bitwise-or) operation:
+To make the [`Int{:tact}`][int] value for `mode` parameter, you just have to combine base modes with optional flags by applying the [bitwise OR](/book/operators#binary-bitwise-or) operation:
 
 ```tact
 nativeReserve(ton("0.1"), ReserveExact | ReserveBounceIfActionFail);

--- a/pages/ref/core-base.mdx
+++ b/pages/ref/core-base.mdx
@@ -16,7 +16,7 @@ Usage example:
 
 ```tact
 contract AllYourStorageBelongsToUs {
-    // This would change the behaviour of self.reserve() function,
+    // This would change the behaviour of self.forward() function,
     // causing it to try reserving this amount of nanoToncoins before
     // forwarding a message with SendRemainingBalance mode
     override const storageReserve = ton("0.1");

--- a/pages/ref/core-base.mdx
+++ b/pages/ref/core-base.mdx
@@ -2,7 +2,7 @@
 
 import { Callout } from 'nextra-theme-docs'
 
-Every [contract](/book/contracts) and [trait](/book/types#traits) in Tact implicitly inherits the `Base{:tact}` trait, which contains a number of the most useful [internal functions](/book/contracts#internal-functions) for any kind of contract, and a constant `storageReserve` aimed at advanced users of Tact.
+Every [contract](/book/contracts) and [trait](/book/types#traits) in Tact implicitly inherits the `Base{:tact}` trait, which contains a number of the most useful [internal functions](/book/contracts#internal-functions) for any kind of contract, and a constant `self.storageReserve{:tact}` aimed at advanced users of Tact.
 
 ## Constants
 
@@ -31,7 +31,7 @@ contract AllYourStorageBelongsToUs {
 virtual fun reply(body: Cell?);
 ```
 
-An alias to calling the [`forward(){:tact}`](#self-forward) function with the following arguments:
+An alias to calling the [`self.forward(){:tact}`](#self-forward) function with the following arguments:
 
 ```tact
 self.forward(sender(), body, true, null);
@@ -55,7 +55,7 @@ self.reply("Beware, this is my reply to you!".asComment());
 virtual fun notify(body: Cell?);
 ```
 
-An alias to calling the [`forward(){:tact}`](#self-forward) function with the following arguments:
+An alias to calling the [`self.forward(){:tact}`](#self-forward) function with the following arguments:
 
 ```tact
 self.forward(sender(), body, false, null);
@@ -81,7 +81,7 @@ virtual fun forward(to: Address, body: Cell?, bounce: Bool, init: StateInit?);
 
 Sends a bounceable or non-bounceable message to the specified address `to`. Optionally, you may provide a `body` of the message and the [`init` package](/book/expressions#initof).
 
-When [`storageReserve{:tact}`](#self-storagereserve) constant is overwritten to be $> 0$, before sending a message it also tries to reserve the `storageReserve{:tact}` amount of nanoToncoins from the remaining balance before making the send in the [`SendRemainingBalance{:tact}`](https://docs.tact-lang.org/book/message-mode#base-modes) ($128$) mode.
+When [`self.storageReserve{:tact}`](#self-storagereserve) constant is overwritten to be $> 0$, before sending a message it also tries to reserve the `self.storageReserve{:tact}` amount of nanoToncoins from the remaining balance before making the send in the [`SendRemainingBalance{:tact}`](https://docs.tact-lang.org/book/message-mode#base-modes) ($128$) mode.
 
 In case reservation attempt fails and in the default case without the attempt, the message is sent with the [`SendRemainingValue{:tact}`](https://docs.tact-lang.org/book/message-mode#base-modes) ($64$) mode instead.
 

--- a/pages/ref/standard-libraries.mdx
+++ b/pages/ref/standard-libraries.mdx
@@ -15,10 +15,10 @@ import "@stdlib/deploy";
 
 Library                  | Description                                                      | Commonly used APIs
 :----------------------- | :--------------------------------------------------------------- | :-----------------
-[`@stdlib/config`][1]    | Config and elector address retrieval.                            | [`getConfigAddress{:tact}`][gca], [`getElectorAddress{:tact}`][gea]
-[`@stdlib/content`][2]   | Encoding off-chain link [strings][p] to a [`Cell{:tact}`][p].    | [`createOffchainContent{:tact}`][coff]
+[`@stdlib/config`][1]    | Config and elector address retrieval.                            | [`getConfigAddress(){:tact}`][gca], [`getElectorAddress(){:tact}`][gea]
+[`@stdlib/content`][2]   | Encoding off-chain link [strings][p] to a [`Cell{:tact}`][p].    | [`createOffchainContent(){:tact}`][coff]
 [`@stdlib/deploy`][3]    | Unified mechanism for deployments.                               | [`Deployable{:tact}`][dep], [`FactoryDeployable{:tact}`][fcd]
-[`@stdlib/dns`][4]       | Resolution of [DNS][dns] names.                                  | [`DNSResolver{:tact}`][dnsr], [`dnsInternalVerify{:tact}`][dnsi]
+[`@stdlib/dns`][4]       | Resolution of [DNS][dns] names.                                  | [`DNSResolver{:tact}`][dnsr], [`dnsInternalVerify(){:tact}`][dnsi]
 [`@stdlib/ownable`][5]   | Traits for ownership management.                                 | [`Ownable{:tact}`][own], [`OwnableTransferable{:tact}`][ownt]
 [`@stdlib/stoppable`][6] | Traits that allow contract stops. Requires [@stdlib/ownable][5]. | [`Stoppable{:tact}`][stp], [`Resumable{:tact}`][res]
 

--- a/pages/ref/stdlib-ownable.mdx
+++ b/pages/ref/stdlib-ownable.mdx
@@ -88,7 +88,7 @@ trait OwnableTransferable with Ownable {
         self.owner = msg.newOwner;
 
         // Reply result
-        self.reply(ChangeOwnerOk{ queryId: msg.queryId, newOwner:msg.newOwner }.toCell());
+        self.reply(ChangeOwnerOk{ queryId: msg.queryId, newOwner: msg.newOwner }.toCell());
     }
 }
 ```

--- a/pages/ref/stdlib-ownable.mdx
+++ b/pages/ref/stdlib-ownable.mdx
@@ -34,7 +34,7 @@ message ChangeOwnerOk {
 
 [Trait](/book/types#composite-types) `Ownable{:tact}` declares an owner (non-editable) of a [contract](/book/contracts) and provides a helper function `requireOwner(){:tact}` that checks that a message was sent by an owner.
 
-This [trait](/book/types#composite-types) requires a field `owner: Address{:tact}` to be declared and exposes get-method `owner` to read it from the [contract](/book/contracts).
+This [trait](/book/types#composite-types) requires a field `owner: Address{:tact}` to be declared and exposes a [getter function](/book/functions#getter-functions) `owner(){:tact}`, which reads it from the [contract](/book/contracts).
 
 Source code:
 

--- a/pages/ref/stdlib-stoppable.mdx
+++ b/pages/ref/stdlib-stoppable.mdx
@@ -12,7 +12,7 @@ import "@stdlib/stoppable"; // this would automatically import @stdlib/ownable t
 
 ### Stoppable
 
-[Trait](/book/types#composite-types) `Stoppable{:tact}` implements receiver for the [Message](/book/structs-and-messages#messages) [string](/book/types#primitive-types) "Stop" that can be sent by owner, implements `stopped` get-method that returns `true{:tact}` if contract is stopped (or `false{:tact}` otherwise) and provides private (non-getter) functions `requireNotStopped(){:tact}` and `requireStopped(){:tact}`.
+[Trait](/book/types#composite-types) `Stoppable{:tact}` implements receiver for the [Message](/book/structs-and-messages#messages) [string](/book/types#primitive-types) "Stop" that can be sent by owner, implements `stopped(){:tact}` [getter function](/book/functions#getter-functions) that returns `true{:tact}` if contract is stopped (or `false{:tact}` otherwise) and provides private (non-getter) functions `requireNotStopped(){:tact}` and `requireStopped(){:tact}`.
 
 Source code:
 


### PR DESCRIPTION
* Capitalized type letters in `map<k, v>` to be `map<K, V>`
* Added `()` after any reference to a function name
* Prefixed things in `core-base.mdx` with `self.`
* Various smaller corrections, like removal of highlighting for "bitwise OR" literally (not to be confused with highlighting of the operator `|`)

Closes #195