### PR TITLE
Update statements.mdx with warning over iterating members of a struct

### DIFF
--- a/pages/book/statements.mdx
+++ b/pages/book/statements.mdx
@@ -280,7 +280,7 @@ dump(sum); // 1000
   }
   ```
 
-  Trying to iterate over a member of a [Struct](/book/structs-and-messages#structs) also won't work:
+  Trying to iterate over a member of a [Struct](/book/structs-and-messages#structs) also won't work, because struct field access is a compound expression and not an identifier:
 
   ```tact
   foreach (k, v in myStruct.myMap) {

--- a/pages/book/statements.mdx
+++ b/pages/book/statements.mdx
@@ -280,7 +280,7 @@ dump(sum); // 1000
   }
   ```
 
-In a similar way, trying to iterate over a member of a struct won't work:
+  Trying to iterate over a member of a [Struct](/book/structs-and-messages#structs) also won't work:
 
   ```tact
   foreach (k, v in myStruct.myMap) {

--- a/pages/book/statements.mdx
+++ b/pages/book/statements.mdx
@@ -280,6 +280,15 @@ dump(sum); // 1000
   }
   ```
 
+In a similar way, trying to iterate over a member of a struct won't work:
+
+  ```tact
+  foreach (k, v in myStruct.myMap) {
+  //               ^ this will give a rather cryptic error message:
+  //                 Syntax error: expected ")"
+  }
+  ```
+
 </Callout>
 
 <Callout>


### PR DESCRIPTION
Based on this conversation in the Tact tg group:

![image](https://github.com/tact-lang/tact-docs/assets/12871/314d6477-1c49-42ab-9026-d8502103074b)
