### PR TITLE
typo: FunC language name

### DIFF
--- a/pages/book/functions.mdx
+++ b/pages/book/functions.mdx
@@ -96,7 +96,7 @@ extends mutates fun customPow(self: Int, c: Int) {
 
 ## Native functions
 
-Native functions are direct bindings of func functions:
+Native functions are direct bindings of FunC functions:
 
 > **Note**
 > Native functions could be also mutable and extension ones.

--- a/pages/book/lifecycle.mdx
+++ b/pages/book/lifecycle.mdx
@@ -8,7 +8,7 @@ This phase combines multiple low-level phases.
 
 It starts by adding a **message value to the contract balance**. The value of an incoming message is the maximum price that a contract can pay for gas to process this message. The contract can overwrite this limit, but it is not recommended and is suitable only for advanced developers since it could lead to a contract being drained. 1 million of gas is the maximum amount that a contract can spend in a single contract which equals 1 TON (currently). If the message value is zero then execution is aborted.
 
-Then some (usually a small amount) of nanotons is subtracted from the contract balance for storage. This means that you can't perfectly predict balance changes and have to adjust your code to this instability.
+Then some (usually a small amount) of nanotons are subtracted from the contract balance for storage. This means that you can't perfectly predict balance changes and have to adjust your code to this instability.
 
 Then it deploys a contract if it is not deployed yet and the message contains the init package. If the init package isn't present, it will be ignored.
 
@@ -16,7 +16,7 @@ Then it deploys a contract if it is not deployed yet and the message contains th
 
 This phase executes the code of a smart contract and produces a list of actions or an exception. Currently, only two types of actions are supported: **send message** and **reserve**.
 
-Sending a message could use a fixed value or a dynamic value like **remaining value of a message** - the remaining of value of the incoming message. Sending a message could be with a flag `SendIgnoreErrors` that would ignore errors during message sending and would continue to the next action. This flag is useful if you have multiple actions. When sending a message with some value, it first subtracts this value from the incoming value and only then from the contract balance (before processing).
+Sending a message could use a fixed value or a dynamic value like **remaining value of a message** - the remaining value of the incoming message. Sending a message could be with a flag `SendIgnoreErrors` that would ignore errors during message sending and would continue to the next action. This flag is useful if you have multiple actions. When sending a message with some value, it first subtracts this value from the incoming value and only then from the contract balance (before processing).
 
 ## Action Phase
 

--- a/pages/book/lifecycle.mdx
+++ b/pages/book/lifecycle.mdx
@@ -8,7 +8,7 @@ This phase combines multiple low-level phases.
 
 It starts by adding a **message value to the contract balance**. The value of an incoming message is the maximum price that a contract can pay for gas to process this message. The contract can overwrite this limit, but it is not recommended and is suitable only for advanced developers since it could lead to a contract being drained. 1 million of gas is the maximum amount that a contract can spend in a single contract which equals 1 TON (currently). If the message value is zero then execution is aborted.
 
-Then some (usually a small amount) of nanotons are subtracted from the contract balance for storage. This means that you can't perfectly predict balance changes and have to adjust your code to this instability.
+Then some (usually small) amount of nanotons gets subtracted from the contract balance for storage. This means that you can't perfectly predict balance changes and have to adjust your code to this instability.
 
 Then it deploys a contract if it is not deployed yet and the message contains the init package. If the init package isn't present, it will be ignored.
 

--- a/pages/book/masterchain.mdx
+++ b/pages/book/masterchain.mdx
@@ -10,7 +10,7 @@ Most of the contract developers don't need a masterchain. Masterchain is needed 
 
 ## How contract is protected from masterchain
 
-Most of the contracts written in `func` enforce all incoming addresses to be `basechain` ones. This is done to prevent masterchain addresses from being used in the contract. Tact does this **by default**.
+Most of the contracts written in `FunC` enforce all incoming addresses to be `basechain` ones. This is done to prevent masterchain addresses from being used in the contract. Tact does this **by default**.
 
 What is prohibited to do without masterchain support enabled:
 * Deploy contract to masterchain. The `init` function would throw a `Masterchain support is not enabled for this contract` error for every message.

--- a/pages/book/masterchain.mdx
+++ b/pages/book/masterchain.mdx
@@ -10,7 +10,7 @@ Most of the contract developers don't need a masterchain. Masterchain is needed 
 
 ## How contract is protected from masterchain
 
-Most of the contracts written in `FunC` enforce all incoming addresses to be `basechain` ones. This is done to prevent masterchain addresses from being used in the contract. Tact does this **by default**.
+Most of the contracts written in FunC enforce all incoming addresses to be `basechain` ones. This is done to prevent masterchain addresses from being used in the contract. Tact does this **by default**.
 
 What is prohibited to do without masterchain support enabled:
 * Deploy contract to masterchain. The `init` function would throw a `Masterchain support is not enabled for this contract` error for every message.

--- a/pages/book/upgrades.mdx
+++ b/pages/book/upgrades.mdx
@@ -1,3 +1,3 @@
 # Contracts upgrades
 
-Tact currently doesn't allow contract upgrades since Tact contracts have a more convoluted nature than the ones in `FunC`. It is theoretically possible, but the required tools are not here.
+Tact currently doesn't allow contract upgrades since Tact contracts have a more convoluted nature than the ones in FunC. It is theoretically possible, but the required tools are not here.

--- a/pages/book/upgrades.mdx
+++ b/pages/book/upgrades.mdx
@@ -1,3 +1,3 @@
 # Contracts upgrades
 
-Tact currently doesn't allow contract upgrades since Tact contracts have a more convoluted nature than the ones in `func`. It is theoretically possible, but the required tools are not here.
+Tact currently doesn't allow contract upgrades since Tact contracts have a more convoluted nature than the ones in `FunC`. It is theoretically possible, but the required tools are not here.


### PR DESCRIPTION
Based on TON FunC document the structure of the `FunC` language name should have capital `F` and `C`, and there is a possibility of misunderstanding between the `FunC language` and `fun` expression or function synonym.

That was what happened to me personally