### PR TITLE
feat: examples of all send modes

### DIFF
--- a/pages/book/message-mode.mdx
+++ b/pages/book/message-mode.mdx
@@ -54,6 +54,8 @@ send(SendParameters{
 
   Also note, that there can be only one [base mode](#base-modes), but number of [optional flags](#optional-flags) may vary: you can use them all, none or just some.
 
+  See more examples: [Single-contract communication in the Cookbook](/cookbook/single-communication).
+
 </Callout>
 
 [int]: /book/integers

--- a/pages/book/send.mdx
+++ b/pages/book/send.mdx
@@ -1,5 +1,7 @@
 # Sending messages
 
+import { Callout } from 'nextra/components'
+
 TON blockchain is message-based — to communicate with other contracts and to deploy new ones you need to send messages.
 
 Messages in Tact are composed using a built-in [Struct](/book/structs-and-messages#structs) `SendParameters{:tact}`, which consists of:
@@ -94,6 +96,12 @@ send(SendParameters{
     body: "Hello, World!".asComment(), // not necessary, can be omitted
 });
 ```
+
+<Callout>
+
+  See more examples of sending messages: [Single-contract communication in the Cookbook](/cookbook/single-communication).
+
+</Callout>
 
 [p]: /book/types#primitive-types
 [int]: /book/integers

--- a/pages/cookbook/single-communication.mdx
+++ b/pages/cookbook/single-communication.mdx
@@ -10,20 +10,157 @@ For examples of communication between multiple deployed contracts see: [Multi-co
 
 ```tact
 receive() {
-    self.reply("Hello, World!".asComment()); // asComment converts a String to a Cell with a comment
+    self.reply("Hello, World!".asComment());
 }
 ```
 
-## How to send a simple message
+<Callout>
+
+  **Useful links:**\
+  [`self.reply(){:tact}` in Core library](/ref/core-base#self-reply)\
+  [`String.asComment(){:tact}` in Core library](/ref/core-strings#stringascomment)
+
+</Callout>
+
+## How to send a regular message
+
+### With a default mode and no optional flags [#regular-default]
 
 ```tact
 send(SendParameters{
     bounce: true, // default
-    to: destinationAddress,
-    value: ton("0.01"), // attached amount of Tons to send
-    body: "Hello from Tact!".asComment(), // comment (optional)
+    to: someDestinationAddress,
+    value: ton("0.1"), // attached amount of Tons to send
+    body: "Hello from Tact!".asComment(), // comment as a body (optional)
 });
 ```
+
+### With `SendPayGasSeparately` [#regular-paygasseparately]
+
+Paying [forward fees](https://docs.ton.org/develop/smart-contracts/guidelines/processing) separately from the message value.
+
+```tact
+send(SendParameters{
+    // bounce: true by default
+    to: groundControl,
+    value: ton("0.1"), // attached amount of Tons to send
+    mode: SendPayGasSeparately,
+});
+```
+
+### With `SendIgnoreErrors` [#regular-sendignoreerrors]
+
+Ignoring any errors arising while processing this message during the [action phase](https://docs.ton.org/learn/tvm-instructions/tvm-overview#transactions-and-phases).
+
+```tact
+send(SendParameters{
+    // bounce: true by default
+    to: majorTom,
+    value: ton("0.1"), // attached amount of Tons to send
+    mode: SendIgnoreErrors,
+});
+```
+
+### With `SendBounceIfActionFail` [#regular-sendbounceifactionfail]
+
+Bouncing the transaction in case of any errors during action phase. Has no effect if flag [`SendIgnoreErrors{:tact}`](#regular-sendignoreerrors) is used.
+
+```tact
+send(SendParameters{
+    // bounce: true by default
+    to: deepThought,
+    value: ton("0.1"), // attached amount of Tons to send
+    mode: SendBounceIfActionFail,
+});
+```
+
+### With `SendDestroyIfZero` [#regular-senddestroyifzero]
+
+Destroing current contract if its resulting balance is zero (often used with mode [`SendRemainingBalance{:tact}`](#remainingbalance-default)).
+
+```tact
+send(SendParameters{
+    // bounce: true by default
+    to: zaphodBeeblebrox,
+    value: ton("0.1"), // attached amount of Tons to send
+    mode: SendDestroyIfZero,
+});
+```
+
+## How to send a message carrying all the remaining value
+
+### Without optional flags, `SendRemainingValue` [#remainingvalue-default]
+
+Carrying all the remaining value of the inbound message (the one we've just received) in addition to the value initially indicated in the message (the one we're about to send).
+
+```tact
+send(SendParameters{
+    // bounce: true by default
+    to: jamesBond,
+    value: ton("0.1"), // attached amount of Tons to send
+    mode: SendRemainingValue,
+});
+```
+
+### With `SendPayGasSeparately` [#remainingvalue-paygasseparately]
+
+```tact
+send(SendParameters{
+    // bounce: true by default
+    to: groundControl,
+    value: ton("0.1"), // attached amount of Tons to send
+    mode: SendRemainingValue | SendPayGasSeparately,
+});
+```
+
+### With `SendIgnoreErrors` [#remainingvalue-sendignoreerrors]
+
+```tact
+send(SendParameters{
+    // bounce: true by default
+    to: majorTom,
+    value: ton("0.1"), // attached amount of Tons to send
+    mode: SendRemainingValue | SendIgnoreErrors,
+});
+```
+
+### With `SendBounceIfActionFail` [#remainingvalue-sendbounceifactionfail]
+
+```tact
+send(SendParameters{
+    // bounce: true by default
+    to: deepThought,
+    value: ton("0.1"), // attached amount of Tons to send
+    mode: SendRemainingValue | SendBounceIfActionFail,
+});
+```
+
+### With `SendDestroyIfZero` [#remainingvalue-senddestroyifzero]
+
+```tact
+send(SendParameters{
+    // bounce: true by default
+    to: zaphodBeeblebrox,
+    value: ton("0.1"), // attached amount of Tons to send
+    mode: SendRemainingValue | SendDestroyIfZero,
+});
+```
+
+## How to send a message carrying all the remaining balance
+
+### Without optional flags, `SendRemainingBalance` [#remainingbalance-default]
+
+TODO
+
+and x4 from prev thing
+
+"X"
+"Like X, but also"
+"Like X, but also"
+"Like X, but also"
+"Like X, but also"
+
+TODO: re-do other things below
 
 ## How to send a message with the entire balance
 
@@ -89,7 +226,7 @@ send(SendParameters{
 
   **Useful links:**\
   ["Sending messages" in the Book](/book/send#send-message)\
-  ["Message `mode`" in the Book](/book/message-mode)
+  ["Message `mode`" in the Book](/book/message-mode)\
   [`StringBuilder{:tact}` in the Book](/book/types#primitive-types)\
   [`Cell{:tact}` in Core library](/ref/core-cells)
 


### PR DESCRIPTION
WIP: Working out potential structure. Thing is, there are 2^4 combinations for so-called optional flags and 3 base modes (including none), which makes the whole page a bit unwieldy (48 examples of `send()`).

I'll figure out something, there was a way to make a dynamic code block via Nextra (the doc theme we're using) even in SSG mode.

Closes #150