### PR TITLE
chore: moved exit codes page in "Fundamentals of Tact"

### DIFF
--- a/pages/book/_meta.js
+++ b/pages/book/_meta.js
@@ -12,6 +12,7 @@ export default {
   'structs-and-messages': 'Structs and Messages',
   optionals: 'Optionals',
   contracts: 'Contracts',
+  'exit-codes': 'Exit codes',
   '-- 2': {
     type: 'separator',
     title: 'Expressiveness',
@@ -45,7 +46,6 @@ export default {
   config: 'Configuration',
   masterchain: 'Masterchain',
   func: 'Compatibility with FunC',
-  'exit-codes': 'Exit codes',
   programmatic: 'Programmatic API',
   '-- Community': {
     type: 'separator',

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -106,7 +106,10 @@ Alternatively, check the following cheatsheets to quickly get started:
 
 ### Want to know more? [#next-2]
 
-For further guidance on compilation, testing and deployment see the [Getting started](/book/guides/getting-started) guide.
+For further guidance on compilation, testing and deployment see the [Getting started](/book/guides/getting-started) guide and respective pages:
+
+* [Testing and debugging](/book/debug) page tells you everything about debugging Tact contracts
+* [Deployment](/book/deploy) page shows what deployment looks like and helps you harness the powers of [Blueprint](https://github.com/ton-org/blueprint) for it.
 
 For custom plugins for your favorite editor and other tooling see the [Tools](/ecosystem/tools/overview) page.
 
@@ -141,7 +144,9 @@ Alternatively, take a look at the following broader sections:
 
 ### Feeling a bit uncomfortable? [#next-3]
 
-If you ever get stuck, don't hesitate to reach out to Tact's flourishing community:
+If you ever get stuck, try searching — the search box is right at the top of the documentation. There is also a handy `Ctrl + K` shortcut to quickly focus and start the search as you type.
+
+If you can't find the answer in the docs, or you've tried to do some local testing and it still didn't help — don't hesitate to reach out to Tact's flourishing community:
 
 <Cards>
   <Cards.Card

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -144,7 +144,7 @@ Alternatively, take a look at the following broader sections:
 
 ### Feeling a bit uncomfortable? [#next-3]
 
-If you ever get stuck, try searching — the search box is right at the top of the documentation. There is also a handy `Ctrl + K` shortcut to quickly focus and start the search as you type.
+If you ever get stuck, try searching — the search box is right at the top of the documentation. There is also a handy <kbd>Ctrl</kbd> + <kbd>K</kbd> shortcut to quickly focus and start the search as you type.
 
 If you can't find the answer in the docs, or you've tried to do some local testing and it still didn't help — don't hesitate to reach out to Tact's flourishing community:
 


### PR DESCRIPTION
...and also slightly updated the index page to encourage people to search and seek answers themselves first, before they go in Tact chats. That won't work on everyone, of course, but it's important to at least mention that we have the search box :)

Closes #328