### PR TITLE
feat: underscores as parameter names in receivers

### DIFF
--- a/pages/book/contracts.mdx
+++ b/pages/book/contracts.mdx
@@ -305,6 +305,18 @@ contract HelloWorld {
 }
 ```
 
+Naming a parameter of the receiver function with an underscore `_{:tact}` makes its value considered unused and discarded. This is useful when you don't need to inspect the message received and you only want it to convey a specific opcode:
+
+```tact
+message(42) UniverseCalls {}
+
+contract Example {
+    receive(_: UniverseCalls) {
+        // Got a Message with opcode 42
+    }
+}
+```
+
 ### Internal functions
 
 These functions behave similarly to private methods in popular object-oriented languages — they're internal to contracts and can be called by prefixing them with a special [identifier `self{:tact}`](#field-access). That's why internal functions can sometimes be referred to as "contract methods".

--- a/pages/book/receive.mdx
+++ b/pages/book/receive.mdx
@@ -37,3 +37,15 @@ contract MyContract {
     }
 }
 ```
+
+Naming a parameter of the receiver function with an underscore `_{:tact}` makes its value considered unused and discarded. This is useful when you don't need to inspect the message received and you only want it to convey a specific opcode:
+
+```tact
+message(42) UniverseCalls {}
+
+contract Example {
+    receive(_: UniverseCalls) {
+        // Got a Message with opcode 42
+    }
+}
+```


### PR DESCRIPTION
Closes #285

I'll remove duplication when resolving #131: receive(), bounced() and external() will have full descriptions on their individual pages, and other places such as functions page and contracts page would briefly show how they look and provide links to "Read more" for all the details. That's because receivers are less of a syntax construct and more of a bigger conceptual thing tightly related to the message and actor-based model of TON Blockchain.