### PR TITLE
fix: clarify bounds of values in `repeat` statement

### DIFF
--- a/pages/book/statements.mdx
+++ b/pages/book/statements.mdx
@@ -239,7 +239,7 @@ Conditionally repeat certain blocks of code multiple times.
 
 ### `repeat` [#repeat-loop]
 
-The `repeat{:tact}` loop executes a block of code a specified number of times. The number of repetitions must be given as a positive $32$-bit [`Int{:tact}`][int] in the inclusive range from $1$ to $2^{31} - 1$. If the value is greater, an error with the [exit code 5](/book/exit-codes#5), `Integer out of the expected range` would be thrown.
+The `repeat{:tact}` loop executes a block of code a specified number of times. The number of repetitions should be given as a positive $32$-bit [`Int{:tact}`][int] in the inclusive range from $1$ to $2^{31} - 1$. If the value is greater, an error with the [exit code 5](/book/exit-codes#5), `Integer out of the expected range` would be thrown.
 
 If the specified number of repetitions is equal to $0$ or any negative number in the inclusive range $-2^{256}$ to $-1$, it is ignored and the code block is not executed at all.
 

--- a/pages/book/statements.mdx
+++ b/pages/book/statements.mdx
@@ -239,15 +239,24 @@ Conditionally repeat certain blocks of code multiple times.
 
 ### `repeat` [#repeat-loop]
 
-The `repeat{:tact}` loop executes a block of code a specified number of times. Number of repetitions must be a non-negative $32$-bit [`Int{:tact}`][int]. Otherwise an error with the [exit code 5](/book/exit-codes#5), `Integer out of the expected range` would be thrown.
+The `repeat{:tact}` loop executes a block of code a specified number of times. The number of repetitions must be given as a positive $32$-bit [`Int{:tact}`][int] in the inclusive range from $1$ to $2^{31} - 1$. If the value is greater, an error with the [exit code 5](/book/exit-codes#5), `Integer out of the expected range` would be thrown.
 
-In the following example, code inside the loop will be executed $10$ times:
+If the specified number of repetitions is equal to $0$ or any negative number in the inclusive range $-2^{256}$ to $-1$, it is ignored and the code block is not executed at all.
 
 ```tact
 let twoPow: Int = 1;
-repeat (10) {  // repeat exactly 10 times
+
+// Repeat exactly 10 times
+repeat (10) {
     twoPow *= 2;
 }
+
+// Skipped
+repeat (-1) {
+    twoPow *= 3333;
+}
+
+twoPow; // 1024
 ```
 
 ### `while` [#while-loop]


### PR DESCRIPTION
Closes #347