### PR TITLE
Remove queryId from index.mdx

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -47,7 +47,6 @@ Here's how it would look like:
 import "@stdlib/deploy";
 
 message Add {
-    queryId: Int as uint64;
     amount: Int as uint32;
 }
 


### PR DESCRIPTION
The property `queryId` from the `message Add` unused and most likely a typo from copy-pasting.

Taking into account this is the very first Tutorial a new developer sees it might be confusing.